### PR TITLE
fix:Project team layout issues #320

### DIFF
--- a/src/Web/Masa.Tsc.Web.Admin.Rcl/Components/Project/TeamDetail.razor
+++ b/src/Web/Masa.Tsc.Web.Admin.Rcl/Components/Project/TeamDetail.razor
@@ -14,8 +14,8 @@
                     </MListItemContent>
                 </MListItem>
             </MCol>
-            <MCol Cols=6 Class="regular--text"><MLabel Class="body2">@I18n.Team("Monitoring Projects") ：</MLabel> <span class="subtitle2">@Value.ProjectTotal</span></MCol>
-            <MCol Cols=6 Class="regular--text"><MLabel Class="body2">@I18n.Team("Monitoring Applications") ：</MLabel><span class="subtitle2">@Value.AppTotal</span></MCol>
+            <MCol Cols=6 Class="regular--text"><span class="body2">@I18n.Team("Monitoring Projects")</span><span class="subtitle2">@($" {Value.ProjectTotal}")</span></MCol>
+            <MCol Cols=6 Class="regular--text"><span class="body2">@I18n.Team("Monitoring Applications")</span><span class="subtitle2">@($" {Value.AppTotal}")</span></MCol>
         </MRow>
         <MRow>
             @foreach (var user in Value.Admins!)
@@ -31,7 +31,7 @@
             }
         </MRow>
         <MRow>
-            <MCol Cols=12 Class="regular2--text body2" Style="min-height:120px">
+            <MCol Cols=12 Class="regular--text body2" Style="min-height:120px">
                 @(Value.Description)
             </MCol>
         </MRow>


### PR DESCRIPTION
左下侧团队信息，1. 监测项目和监测应用后面没有：冒号。2. 描述会根据内容自适应高度
![1680594872698](https://user-images.githubusercontent.com/38368335/229726871-70f2329c-3dc1-4c56-a5d5-bfa2dd786234.jpg)
