### PR TITLE
fix:Dashboard Card not in center problem

### DIFF
--- a/src/Web/Masa.Tsc.Web.Admin.Rcl/Components/Dashboards/Configurations/PanelSelect.razor
+++ b/src/Web/Masa.Tsc.Web.Admin.Rcl/Components/Dashboards/Configurations/PanelSelect.razor
@@ -2,8 +2,8 @@
 
 @if (ConfigurationRecord.IsEdit)
 {
-    <div style="height:100%;width:100%;" class="d-flex pa-3">
-        <div class="ma-auto" style="display: flex;flex-wrap: wrap;max-width: 480px;">
+    <div style="height:100%;width:100%;" class="d-flex">
+        <div class="ma-auto pl-5" style="display: flex;flex-wrap: wrap;max-width: 504px;">
             @foreach (var panelType in GetPanelTypes())
             {
                 <MHover Disabled=panelType.Disabled>


### PR DESCRIPTION
已居中，4k和1920显示效果如下
![image](https://user-images.githubusercontent.com/38368335/231680853-e9609b86-fa69-42a5-be3c-c8efd641168c.png)
![image](https://user-images.githubusercontent.com/38368335/231680931-fd7690d7-a3fa-4096-9590-a805ceedef9a.png)
